### PR TITLE
Some suggestions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -264,6 +264,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
 
                   const id = shareResponse.notebook.readable_id || shareResponse.notebook.id;
                   shareableLink = sharingService.makeRetrieveURL(id).toString();
+                  notebookPasswords.set(shareResponse.notebook.id, password);
                 }
 
                 if (shareableLink) {
@@ -293,7 +294,6 @@ const plugin: JupyterFrontEndPlugin<void> = {
               }
             }
           } else {
-            // Already shared - just show the link (no password, no name dialog)
             await handleNotebookSave(notebookPanel, true);
           }
         } catch (error) {

--- a/src/sharing-service.ts
+++ b/src/sharing-service.ts
@@ -127,15 +127,6 @@ export class SharingService {
 
   /** The current authentication token. */
   private _token?: IToken;
-  private _password?: string;
-
-  get password(): string | undefined {
-    return this._password;
-  }
-
-  set password(newPassword: string | undefined) {
-    this._password = newPassword;
-  }
 
   /**
    * Retrieves the current authentication token, authenticating if necessary.

--- a/src/sharing-service.ts
+++ b/src/sharing-service.ts
@@ -127,6 +127,15 @@ export class SharingService {
 
   /** The current authentication token. */
   private _token?: IToken;
+  private _password?: string;
+
+  get password(): string | undefined {
+    return this._password;
+  }
+
+  set password(newPassword: string | undefined) {
+    this._password = newPassword;
+  }
 
   /**
    * Retrieves the current authentication token, authenticating if necessary.

--- a/src/ui-components/share-dialog.tsx
+++ b/src/ui-components/share-dialog.tsx
@@ -74,18 +74,11 @@ export class ShareDialog extends ReactWidget {
  */
 export const createSuccessDialog = (
   shareableLink: string,
-  isNewShare: boolean,
-  isViewOnly: boolean,
   password?: string
-) => {
+): React.JSX.Element => {
   return (
     <div>
-      <h3>
-        {isNewShare
-          ? 'Here is the shareable link to your new copy:'
-          : 'Here is the shareable link to your notebook:'}
-      </h3>
-
+      <h3>Here is the shareable link to your notebook:</h3>
       <div
         style={{
           backgroundColor: '#f0f0f0',
@@ -99,7 +92,7 @@ export const createSuccessDialog = (
         {shareableLink}
       </div>
 
-      {isNewShare && password && (
+      {password && (
         <>
           <p>
             Here's the code required to edit the original notebook. Make sure to save this code as

--- a/ui-tests/tests/jupytereverywhere.spec.ts
+++ b/ui-tests/tests/jupytereverywhere.spec.ts
@@ -52,7 +52,13 @@ test.describe('General', () => {
 test.describe('Save', () => {
   test('Should open share dialog on save', async ({ page }) => {
     await runCommand(page, 'jupytereverywhere:share-notebook');
-    await page.locator('div').filter({ hasText: 'Here is the shareable link to' }).first().click();
+    expect(
+      await page
+        .locator('div')
+        .filter({ hasText: 'Here is the shareable link to' })
+        .first()
+        .screenshot()
+    ).toMatchSnapshot('share.png');
   });
 });
 

--- a/ui-tests/tests/jupytereverywhere.spec.ts
+++ b/ui-tests/tests/jupytereverywhere.spec.ts
@@ -49,19 +49,6 @@ test.describe('General', () => {
   });
 });
 
-test.describe('Save', () => {
-  test('Should open share dialog on save', async ({ page }) => {
-    await runCommand(page, 'jupytereverywhere:share-notebook');
-    expect(
-      await page
-        .locator('div')
-        .filter({ hasText: 'Here is the shareable link to' })
-        .first()
-        .screenshot()
-    ).toMatchSnapshot('share.png');
-  });
-});
-
 test.describe('Sharing', () => {
   test('Should open share dialog', async ({ page }) => {
     const shareButton = page.locator('.jp-ToolbarButton').getByTitle('Share this notebook');


### PR DESCRIPTION
Some minor changes:

- I'm pretty sure you don't need to call `sharingService.token`, because both `sharingService.update` and `sharingService.share` both do so internally.
- You can use object destructuring to update the notebook metadata a bit more compactly

Some design issues:

- When saving the notebook, I don't think any dialog box should pop up.
- When clicking "share", a dialog box with the link and password should show up. To make this work, I added a `notebookPasswords` map. This maps notebook shared IDs to passwords for those notebooks, allowing us to create a password when the user first saves the notebook, and only display it later on when the user clicks "share".

The mockups have a sentence about passwords only being displayed once:

> Here's the code required to edit the original notebook. Make sure to save this code as it will not appear again

but I'm not really sure about whether this is 1. practical, because the user might accidentally close the dialog without copying the password, and 2. necessary, because we can just store the passwords for the notebooks the user has access to. Is there any reason to suspect this is a security concern?

Please review and let me know what you think.
